### PR TITLE
Normalize `mixin` API

### DIFF
--- a/examples/scripts/hybrid.js
+++ b/examples/scripts/hybrid.js
@@ -4,8 +4,8 @@ d3.chart("Hybrid", {
     var barHeight = this.barHeight();
     var barWidth = this.radius * 2;
 
-    var chord = this.chord = this.mixin(this.base.append("g"), "ImprovedChord");
-    var bc = this.bc = this.mixin(this.base.append("g"), "FadingBarChart");
+    var chord = this.chord = this.mixin("ImprovedChord", this.base.append("g"));
+    var bc = this.bc = this.mixin("FadingBarChart", this.base.append("g"));
     chord.transform = function(data) {
       return d3.chart("Chord").prototype.transform(data.series2);
     };

--- a/src/d3-chart.js
+++ b/src/d3-chart.js
@@ -88,7 +88,7 @@
 		return data;
 	};
 
-	Chart.prototype.mixin = function(selection, chartName) {
+	Chart.prototype.mixin = function(chartName, selection) {
 		var args = Array.prototype.slice.call(arguments, 2);
 		args.unshift(selection);
 		var ctor = Chart[chartName];

--- a/test/tests/d3-chart.js
+++ b/test/tests/d3-chart.js
@@ -95,16 +95,16 @@ suite("d3.chart", function() {
 			this.myChart = d3.select("#test").chart("test");
 		});
 		test("instantiates the specified chart", function() {
-			var mixin = this.myChart.mixin(d3.select("body"), "test2", 1, 2, 45);
+			var mixin = this.myChart.mixin("test2", d3.select("body"), 1, 2, 45);
 			assert.instanceOf(mixin, d3.chart("test2"));
 		});
 		test("instantiates with the correct arguments", function() {
-			var mixin = this.myChart.mixin(d3.select("body"), "test2", 1, 2, 45);
+			var mixin = this.myChart.mixin("test2", d3.select("body"), 1, 2, 45);
 			assert.deepEqual(mixin.initialize.args[0], [1, 2, 45]);
 		});
 		test("correctly sets the `base` attribute of the mixin", function() {
 			var mixinBase = d3.select("body");
-			var mixin = this.myChart.mixin(mixinBase, "test2");
+			var mixin = this.myChart.mixin("test2", mixinBase);
 			assert.equal(mixin.base, mixinBase);
 		});
 	});
@@ -130,8 +130,8 @@ suite("d3.chart", function() {
 			});
 			sinon.spy(layer2, "draw");
 
-			this.mixin1 = mixin1 = myChart.mixin(d3.select("#test"), "test");
-			this.mixin2 = mixin2 = myChart.mixin(d3.select("#test"), "test");
+			this.mixin1 = mixin1 = myChart.mixin("test", d3.select("#test"));
+			this.mixin2 = mixin2 = myChart.mixin("test", d3.select("#test"));
 			sinon.stub(mixin1, "draw");
 			sinon.stub(mixin2, "draw");
 		});


### PR DESCRIPTION
Mixin declarations should be similar to te Layer and Chart APIs. Namely,
the first argument to `Chart#mixin` should be the Chart name, the second
should be the selection for the mixin's base, and all following
arguments should be passed through to the mixin Chart's constructor.

This should resolve issue #13
