### PR TITLE
Fix bug in example Chord diagram

### DIFF
--- a/examples/scripts/chord-diagram.js
+++ b/examples/scripts/chord-diagram.js
@@ -65,7 +65,7 @@ d3.chart("Chord", {
 
     this.layer("ticks", base.append("g"), {
       dataBind: function(chord) {
-        return this.append("g").selectAll("g")
+        return this.selectAll("g")
             .data(chord.groups)
           .enter().append("g").selectAll("g")
             .data(groupTicks);


### PR DESCRIPTION
This chart was not built to be re-drawn, so a slight modification is
necessary to enable multiple calls to `Chart#draw`.

This should resolve issue #16
