### PR TITLE
Abstract data dereferencing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,8 +35,8 @@ module.exports = function(grunt) {
           globals: {
             d3: true,
             assert: true,
-            chai: true,
             setup: true,
+            suiteSetup: true,
             teardown: true,
             suite: true,
             test: true,

--- a/src/chart.js
+++ b/src/chart.js
@@ -15,6 +15,19 @@
 		return inst;
 	};
 
+	// Determine if the current environment satisfies d3.chart's requirements
+	// for ECMAScript 5 compliance.
+	var isES5 = (function() {
+		try {
+			Object.defineProperty({}, "test", {
+				get: function() { return true; }
+			});
+		} catch(err) {
+			return false;
+		}
+		return true;
+	})();
+
 	// extend
 	// Borrowed from Underscore.js
 	function extend(object) {
@@ -49,14 +62,105 @@
 		}
 	};
 
-	var Chart = function(selection) {
+	// wrapData
+	// Given a data point, return an object with customized accessors for each
+	// of the chart's data attributes.
+	var wrapDataImpls = {
+		ES5: function(dataPoint) {
+			if (typeof dataPoint !== "object") {
+				return dataPoint;
+			}
+			var dataProxy = Object.create(this._dataProxy);
+			dataProxy._dataPoint = dataPoint;
+
+			return dataProxy;
+		},
+		legacy: function(dataPoint) {
+			var dataProxy, key, getter, dataMapping;
+
+			if (typeof dataPoint !== "object") {
+				return dataPoint;
+			}
+			dataProxy = {};
+
+			dataMapping = this._dataMapping;
+
+			if (!dataMapping) {
+				this.dataAttrs.forEach(function(key) {
+					dataProxy[key] = dataPoint[key];
+				});
+			} else {
+				this.dataAttrs.forEach(function(key) {
+					getter = dataMapping[key];
+					if (getter) {
+						dataProxy[key] = getter.call(dataPoint);
+					} else {
+						dataProxy[key] = dataPoint[key];
+					}
+				}, this);
+			}
+
+			return dataProxy;
+		}
+	};
+
+	var wrapData = wrapDataImpls[ isES5 ? "ES5" : "legacy" ];
+
+	var Chart = function(selection, chartOptions) {
 
 		this.base = selection;
+		this._dataMapping = chartOptions && chartOptions.dataMapping;
 		this._layers = {};
 		this._mixins = [];
 		this._events = {};
 
 		initCascade.call(this, this, Array.prototype.slice.call(arguments, 1));
+
+		// Skip data mapping initialization logic if the chart has explicitly
+		// opted out of that functionality (generally for performance reasons)
+		if (this._dataMapping !== false) {
+			createDataProxy.call(this);
+		}
+
+	};
+
+	// createDataProxy
+	// Initialize a proxy object to facilitate data mapping
+	var createDataProxy = function() {
+		var dataProxy = this._dataProxy = {};
+		var dataMapping = this._dataMapping;
+		var getters;
+
+		if (dataMapping) {
+			getters = {};
+			Object.keys(dataMapping).forEach(function(attr) {
+				getters[attr] = dataMapping[attr];
+			});
+		}
+
+		this.dataAttrs.forEach(function(attr) {
+			var customGetter = getters && getters[attr];
+			var getter;
+
+			if (customGetter) {
+				getter = function() {
+					return customGetter.call(this._dataPoint);
+				};
+			} else {
+				getter = function() {
+					return this._dataPoint[attr];
+				};
+			}
+
+			if (isES5) {
+				Object.defineProperty(dataProxy, attr, {
+					get: getter
+				});
+			} else {
+				dataProxy[attr] = getter;
+			}
+		}, this);
+
 	};
 
 	Chart.prototype.unlayer = function(name) {
@@ -102,7 +206,12 @@
 
 	Chart.prototype.draw = function(data) {
 
-		var layerName, idx, len;
+		var layerName, idx, len, wrappedData;
+
+		if (this._dataMapping !== false && data) {
+			wrappedData = data.map(wrapData, this);
+			data = wrappedData;
+		}
 
 		data = this.transform(data);
 
@@ -190,7 +299,7 @@
 
 	Chart.extend = function(name, protoProps, staticProps) {
 		var parent = this;
-		var child;
+		var child, dataAttrs;
 
 		// The constructor function for the new subclass is either defined by
 		// you (the "constructor" property in your `extend` definition), or
@@ -217,6 +326,12 @@
 		// Set a convenience property in case the parent's prototype is needed
 		// later.
 		child.__super__ = parent.prototype;
+		// Inherit chart data attributes. This allows charts that derive from
+		// other charts to use the same attributes for data without
+		// compromising their ability to add additional attributes.
+		dataAttrs = child.prototype.dataAttrs || [];
+		dataAttrs.push.apply(dataAttrs, parent.prototype.dataAttrs || []);
+		child.prototype.dataAttrs = dataAttrs;
 
 		Chart[name] = child;
 		return child;

--- a/test/tests/chart.js
+++ b/test/tests/chart.js
@@ -135,14 +135,142 @@ suite("d3.chart", function() {
 			sinon.stub(mixin1, "draw");
 			sinon.stub(mixin2, "draw");
 		});
+
+		suite("data accessors", function() {
+			suiteSetup(function() {
+				d3.chart("DataAttrTestChart", {
+					dataAttrs: ["attr1", "attr2", "attr3"]
+				});
+				this.myChart.transform = this.transform;
+			});
+
+			suite("attribute name declaration", function() {
+				test("attribute names declared in chart constructor are accessible", function(done) {
+					var chart = d3.select("#test").chart("DataAttrTestChart");
+					chart.transform = function(wrappedData) {
+						assert.ok(wrappedData[0].attr1);
+						assert.ok(wrappedData[0].attr2);
+						assert.ok(wrappedData[0].attr3);
+
+						done();
+					};
+					chart.draw([{ attr1: 1, attr2: 2, attr3: 3 }]);
+				});
+
+				test("attribute names not declared in chart constructor are inaccessible", function(done) {
+					var chart = d3.select("#test").chart("DataAttrTestChart");
+
+					chart.transform = function(wrappedData) {
+						assert.equal(wrappedData[0].attr4, undefined);
+
+						done();
+					};
+
+					chart.draw([{ attr4: 23 }]);
+				});
+
+				test("names are properly inherited", function(done) {
+					d3.chart("DataAttrTestChart")
+						.extend("ExtendedDataAttrTestChart", {
+							dataAttrs: ["attr4"]
+						});
+
+					var chart = d3.select("#test")
+						.chart("ExtendedDataAttrTestChart");
+					chart.transform = function(wrappedData) {
+						assert.ok(wrappedData[0].attr1);
+						assert.ok(wrappedData[0].attr2);
+						assert.ok(wrappedData[0].attr3);
+						assert.ok(wrappedData[0].attr4);
+
+						done();
+					};
+
+					chart.draw([{ attr1: 1, attr2: 2, attr3: 3, attr4: 4 }]);
+				});
+
+				test("opting out with `dataMapping: false`", function(done) {
+					var chart = d3.select("#test").chart("DataAttrTestChart", {
+						dataMapping: false
+					});
+
+					chart.transform = function(data) {
+						assert.ok(data[0].attr4);
+						done();
+					};
+
+					chart.draw([{ attr4: true }]);
+				});
+
+			});
+
+			suite("mapping", function() {
+				test("primitive data points pass through unmodified", function(done) {
+					d3.chart("SimpleDataAttrTestChart", {});
+					var chart = d3.select("#test")
+						.chart("SimpleDataAttrTestChart");
+					var obj = {};
+					var data = [1, "a string", false, obj];
+					chart.transform = function(data) {
+						assert.equal(data[0], 1);
+						assert.equal(data[1], "a string");
+						assert.equal(data[2], false);
+						assert.notEqual(data[3], obj);
+
+						done();
+					};
+
+					chart.draw(data);
+				});
+
+				test("default accessors dereference data with specified attribute names", function(done) {
+					var chart = d3.select("#test").chart("DataAttrTestChart");
+					var data = [{
+						attr1: 1
+					}, {
+						attr2: 2
+					}, {
+						attr3: 3
+					}];
+					chart.transform = function(data) {
+						assert.equal(data[0].attr1, 1);
+						assert.equal(data[1].attr2, 2);
+						assert.equal(data[2].attr3, 3);
+
+						done();
+					};
+
+					chart.draw(data);
+				});
+
+				test("uses custom accessors when specified", function(done) {
+					var chart = d3.select("#test").chart("DataAttrTestChart", {
+						dataMapping: {
+							attr1: function() { return this.custom; },
+							attr2: function() { return this.deeply.nested; }
+						}
+					});
+					chart.transform = function(data) {
+						assert.equal(data[0].attr1, 23);
+						assert.equal(data[0].attr2, 45);
+						done();
+					};
+
+					chart.draw([{ custom: 23, deeply: { nested: 45 } }]);
+				});
+			});
+		});
+
 		test("invokes the transform method once with the specified data", function() {
-			var data = {};
+			var data = [1, 2, 3];
+			var wrappedData;
 			assert.equal(this.transform.callCount, 0);
 
 			this.myChart.draw(data);
 
 			assert.equal(this.transform.callCount, 1);
-			assert.equal(this.transform.args[0][0], data);
+			wrappedData = this.transform.args[0][0];
+			assert.equal(wrappedData.length, 3);
 		});
 		test("invokes the `draw` method of each of its layers", function() {
 			assert.equal(this.layer1.draw.callCount, 0);
@@ -154,7 +282,7 @@ suite("d3.chart", function() {
 			assert.equal(this.layer2.draw.callCount, 1);
 		});
 		test("invokes the `draw` method of each of its layers with the transformed data", function() {
-			this.myChart.draw({});
+			this.myChart.draw([]);
 
 			assert.equal(this.layer1.draw.args[0][0], this.transformedData);
 			assert.equal(this.layer2.draw.args[0][0], this.transformedData);


### PR DESCRIPTION
In order to better facilitate reusability, this patch provides an interface for working with chart data. With it, Chart consumers are able to define the "shape" of their data.

This approach should address the concerns raised in issues #12 and #22.
### Usage: Chart Definition

Chart authors _must_ specify the data attributes their chart requires through the `dataAttrs` property at Chart definition, i.e.

``` javascript
d3.Chart("AwesomeChart", {
  dataAttrs: ["time", "space"]
});
```

These attributes (and _only_ these attributes) may be accessed from `Chart#transform` and the d3.js selection methods.

``` javascript
this.layer("bars").on("enter", function() {
  this.attr("height", function(d) {
    // Here, d.foo is undefined, even if it exists on
    // the data specified to `Chart#draw`
    return d.time + d.space;
  });
});
```

This behavior is achieved with minimal memory overhead by creating a single object for each data point (but notably not a deep copy of the input data).
### Usage: Chart Consumption

Users of `AwesomeChart` must reference the `dataAttrs` it requests (see above). Any functionality they add to the chart must be in terms of these attributes _regardless of the shape of their data_. If they need to modify how `AwesomeChart` interfaces with their data, they may specify a mapping at Chart initialization time:

``` javascript
var myChart = d3.select("body").chart("AwesomeChart", {
  // These methods will be invoked in the context of each
  // individual data point as the attributes are accessed
  dataMapping: {
    time: function() { return this.somethingElse; },
    space: function() { return this.deeply.nested.attribute; }
  }
});

myChart.draw([{
  somethingElse: 1371073127051,
  deeply: {
    nested: {
      attribute: 0.5
    }
  }
}]);
```

This functionality allows the charts to be authored independently of the "shape" of the input data. It satisfies the requirements of CPU efficiency, mandatoriness, and familiarity.
### Potential Concerns

**Browser Compatibility** This approach should be very familiar for those who are used to working with d3.js. Consumer code does not have to utilize a function to dereference data; objects passed to d3.js methods like `attr` and `text` can be de-referenced directed. This requires the use of `Object.defineProperty` and `Object.create`, which [cannot be shimmed in older browsers](https://github.com/kriskowal/es5-shim). It's worth noting that even though [the Aight library](https://github.com/shawnbot/aight) is [recommended on the d3.js wiki](https://github.com/mbostock/d3/wiki#browser-support), it's unclear if d3.js is actually fully functional in IE8 with that shim.

**Memory Efficiency** It is somewhat memory-inefficient in that it creates new objects for each data point, but I think this is a reasonable trade off. In the future, if users want to create high-performance charts that operate over large data sets, we can consider an API to disable this behavior and allow direct data access.
