### PR TITLE
Fix layer event to match documentation (chain).

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -32,6 +32,7 @@
 			callback: handler,
 			chart: options.chart || null
 		});
+		return this._base;
 	};
 
 	// off
@@ -43,12 +44,12 @@
 		var idx;
 
 		if (!handlers) {
-			return;
+			return this._base;
 		}
 
 		if (arguments.length === 1) {
 			handlers.length = 0;
-			return;
+			return this._base;
 		}
 
 		for (idx = handlers.length - 1; idx > -1; --idx) {
@@ -56,6 +57,7 @@
 				handlers.splice(idx, 1);
 			}
 		}
+		return this._base;
 	};
 
 	// draw

--- a/test/tests/chart.js
+++ b/test/tests/chart.js
@@ -271,6 +271,15 @@ suite("d3.chart", function() {
 					context.chart.trigger("non_existing_event", 12);
 				}, Error);
 			});
+			test("returns the chart instance (chains)", function() {
+				assert.equal(this.chart.trigger("e1"), this.chart);
+			});
+		});
+
+		suite("#on", function () {
+			test("returns the chart instance (chains)", function() {
+				assert.equal(this.chart.on("e1"), this.chart);
+			});
 		});
 
 		suite("#once", function() {
@@ -285,6 +294,9 @@ suite("d3.chart", function() {
 				assert.equal(this.e1callback.callCount, 2);
 				assert.equal(this.e1callback2.callCount, 2);
 				assert.equal(e1oncecallback.callCount, 1);
+			});
+			test("returns the chart instance (chains)", function() {
+				assert.equal(this.chart.once("e1"), this.chart);
 			});
 		});
 
@@ -353,6 +365,9 @@ suite("d3.chart", function() {
 				assert.equal(this.e1callback.callCount, 1);
 				assert.equal(this.e1callback2.callCount, 1);
 				assert.equal(e1callback3.callCount, 1);
+			});
+			test("returns the chart instance (chains)", function() {
+				assert.equal(this.chart.off("e1"), this.chart);
 			});
 		});
 	});

--- a/test/tests/layer.js
+++ b/test/tests/layer.js
@@ -435,4 +435,20 @@ suite("d3.layer", function() {
 			});
 		});
 	});
+	suite("events", function () {
+		setup(function () {
+			var base = this.base = d3.select("#test");
+			this.layer = new base.layer({});
+		});
+		suite("#on", function () {
+			test("returns the layer instance (chains)", function() {
+				assert.equal(this.layer.on("e1"), this.layer);
+			});
+		});
+		suite("#off", function () {
+			test("returns the layer instance (chains)", function() {
+				assert.equal(this.layer.off("e1"), this.layer);
+			});
+		});
+	});
 });


### PR DESCRIPTION
- spec chaining for chart events
- spec chaining for layer events
- implement chaining for layer events.

I think this is a minor improvement.

I was also wondering why the event APIs were different for charts and layers, instead of a single implementation that can be mixed in?
