### PR TITLE
Remove unused variable

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -105,9 +105,8 @@
 		return data;
 	};
 
-	Chart.prototype.mixin = function(chartName, selection) {
-		var args = Array.prototype.slice.call(arguments, 2);
-		args.unshift(selection);
+	Chart.prototype.mixin = function(chartName) {
+		var args = Array.prototype.slice.call(arguments, 1);
 		var ctor = Chart[chartName];
 		var chart = variadicNew(ctor, args);
 


### PR DESCRIPTION
Unless I am missing something, explicit handling of the selection parameter in `Chart.prototype.mixin` is unnecessary.
