### PR TITLE
Document `transform` option for Chart constructor

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -78,7 +78,13 @@ var transformCascade = function(instance, data) {
  * @param {mixed} chartOptions A value for controlling how the chart should be
  *        created. This value will be forwarded to {@link Chart#initialize}, so
  *        charts may define additional properties for consumers to modify their
- *        behavior during initialization.
+ *        behavior during initialization. The following attributes will be
+ *        copied onto the chart instance (if present):
+ *
+ *        - {Function} transform - A data transformation function unique to the
+ *          Chart instance being created. If specified, this function will be
+ *          invoked after all inherited implementations as part of the
+ *          `Chart#draw` operation.
  *
  * @constructor
  */


### PR DESCRIPTION
As part of the release for d3.chart version 0.2, the Chart constructor
was modify to special-case an optional `transform` option, copying it
onto the new chart instance [1]. Document this behavior in the
description of the Chart constructor.

[1] Commit fbb389de0b2c5722faa46ae6b2041bb62b57e7d9
