### PR TITLE
Improve JSDoc usage

### DIFF
--- a/build/tasks/jshint.js
+++ b/build/tasks/jshint.js
@@ -8,6 +8,12 @@ module.exports = function(grunt) {
       },
       src: ["<%= meta.srcFiles %>"]
     },
+    examples: {
+      options: {
+        jshintrc: "examples/api/.jshintrc"
+      },
+      src: ["examples/api/*.js"]
+    },
     test: {
       options: {
         jshintrc: "test/.jshintrc"

--- a/examples/api/.jshintrc
+++ b/examples/api/.jshintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "../../.jshintrc",
+  "unused": false,
+  "globals": {
+    "log": true,
+    "output": true,
+    "d3": true
+  }
+}

--- a/examples/api/chart-attach.js
+++ b/examples/api/chart-attach.js
@@ -1,0 +1,13 @@
+d3.chart("PieBars", {
+  initialize: function() {
+    var barchart = this.base.append("svg")
+      .chart("BarChart");
+
+    var piechart = this.base.append("svg")
+      .chart("PieChart")
+      .radius(10);
+
+    this.attach("bars", barchart);
+    this.attach("piechart", piechart);
+  }
+});

--- a/examples/api/chart-draw.js
+++ b/examples/api/chart-draw.js
@@ -1,0 +1,12 @@
+// assume previously defined d3.chart called
+// CircleChart
+
+// create an instance of the chart on a d3 selection
+var chart = d3.select(output)
+  .append("svg")
+  .attr("height", 30)
+  .attr("width", 400)
+  .chart("CircleChart");
+
+// render it with some data
+chart.draw([1,4,6,9,12,13,30]);

--- a/examples/api/chart-extend.js
+++ b/examples/api/chart-extend.js
@@ -1,0 +1,14 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+    log("Hi! I'm a chart");
+  }
+});
+
+d3.chart("CircleChart").extend("OtherCircleChart", {
+  initialize: function() {
+    log("I am a circle chart based on the one above!");
+  }
+});
+
+var chart = d3.select(output)
+  .chart("OtherCircleChart");

--- a/examples/api/chart-layer.js
+++ b/examples/api/chart-layer.js
@@ -1,0 +1,9 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+    // add a circles layer
+    var circleLayer = this.unlayer("circles");
+
+    // reattach layer
+    this.layer("circles", circleLayer);
+  }
+});

--- a/examples/api/chart-off.js
+++ b/examples/api/chart-off.js
@@ -1,0 +1,23 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+
+  },
+  action: function() {
+    this.trigger("acted", "action executed!");
+  }
+});
+
+var chart = d3.select(output)
+  .chart("CircleChart");
+
+chart.on("acted", function(message){
+  log(message);
+});
+
+// will trigger
+chart.action();
+
+chart.off();
+
+// won't trigger
+chart.action();

--- a/examples/api/chart-on.js
+++ b/examples/api/chart-on.js
@@ -1,0 +1,16 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+  },
+  action: function() {
+    this.trigger("acted", "action executed!");
+  }
+});
+
+var chart = d3.select(output)
+  .chart("CircleChart");
+
+chart.on("acted", function(message){
+  log(message);
+});
+
+chart.action();

--- a/examples/api/chart-once.js
+++ b/examples/api/chart-once.js
@@ -1,0 +1,20 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+
+  },
+  action: function() {
+    this.trigger("acted", "action executed!");
+  }
+});
+
+var chart = d3.select(output)
+  .chart("CircleChart");
+
+chart.once("acted", function(message){
+  log(message);
+});
+
+// will only call the above callback once even
+// though we will trigger twice
+chart.action();
+chart.action();

--- a/examples/api/chart-transform.js
+++ b/examples/api/chart-transform.js
@@ -1,0 +1,20 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+    // assume we create layers and such here.
+  },
+  transform: function(data) {
+    // assume we recieve an object that has 
+    // the data array under a values property like so:
+    // { values: [...] }
+    return data.values;
+  }
+});
+
+var chart = d3.select(output)
+  .append("svg")
+  .attr("height", 30)
+  .attr("width", 400)
+  .chart("CircleChart");
+
+// render it with some data
+log(chart.transform({ values: [1,4,6,9,12,13,30]}));

--- a/examples/api/chart-trigger.js
+++ b/examples/api/chart-trigger.js
@@ -1,0 +1,17 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+
+  },
+  action: function() {
+    this.trigger("acted", "action executed!");
+  }
+});
+
+var chart = d3.select(output)
+  .chart("CircleChart");
+
+chart.on("acted", function(message){
+  log(message);
+});
+
+chart.action();

--- a/examples/api/chart-unlayer.js
+++ b/examples/api/chart-unlayer.js
@@ -1,0 +1,9 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+    // add a circles layer
+    var circleLayer = this.unlayer("circles");
+
+    // reattach layer
+    this.layer("circles", circleLayer);
+  }
+});

--- a/examples/api/chart.js
+++ b/examples/api/chart.js
@@ -1,0 +1,8 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+    log("Hi! I'm a chart");
+  }
+});
+
+var chart = d3.select(output)
+  .chart("CircleChart");

--- a/examples/api/layer-draw.js
+++ b/examples/api/layer-draw.js
@@ -1,0 +1,25 @@
+// define a layer
+var layer = d3.select(output)
+  .append("svg")
+  .attr("width", 100)
+  .attr("height", 100)
+  .layer({
+    dataBind: function(data){
+      return this.selectAll("rect")
+        .data(data);
+    },
+    insert: function() {
+      return this.append("rect");
+    },
+    events: {
+      enter: function() {
+        return this.attr("x", function(d){ return d; })
+          .attr("y", 48)
+          .attr("width", 4)
+          .attr("height",4);
+      }
+    }
+  });
+
+// render the layer
+layer.draw([10,20,50,90]);

--- a/examples/api/layer-off.js
+++ b/examples/api/layer-off.js
@@ -1,0 +1,56 @@
+// define a new chart type: a circle chart
+d3.chart("CircleChart", {
+
+  initialize: function() {
+    // create a layer of circles that will go into
+    // a new group element on the base of the chart
+    var circles = this.layer("circles", this.base.append("g"), {
+
+      // select the elements we wish to bind to and 
+      // bind the data to them.
+      dataBind: function(data) {
+        return this.selectAll("circle")
+          .data(data);
+      },
+
+      // insert actual circles
+      insert: function() {
+        return this.append("circle");
+      }
+    });
+
+    circles.on("enter", function() {
+      return this.attr("cx", function(d) {
+        return d * 10;
+      })
+      .attr("cy", 10)
+      .attr("r", 0)
+      .style("fill", "red");
+    });
+
+    circles.on("enter", this.broadcast);
+
+    circles.on("enter:transition", function() {
+      return this.delay(500)
+            .attr("r", 5)
+            .style("fill", "blue");
+    });
+  },
+  broadcast: function() {
+    log("broadcast!");
+  }
+});
+
+// create an instance of the chart on a d3 selection
+var chart = d3.select(output)
+  .append("svg")
+  .attr("height", 30)
+  .attr("width", 400)
+  .chart("CircleChart");
+
+// removing the broadcast callback will cause it NOT to 
+// trigger. Try it out, comment this out.
+chart.layer("circles").off("enter", chart.broadcast);
+
+// render it with some data
+chart.draw([1,4,6,9,12,13,30]);

--- a/examples/api/layer-on.js
+++ b/examples/api/layer-on.js
@@ -1,0 +1,47 @@
+// define a new chart type: a circle chart
+d3.chart("CircleChart", {
+
+  initialize: function() {
+    // create a layer of circles that will go into
+    // a new group element on the base of the chart
+    var circles = this.layer("circles", this.base.append("g"), {
+
+      // select the elements we wish to bind to and 
+      // bind the data to them.
+      dataBind: function(data) {
+        return this.selectAll("circle")
+          .data(data);
+      },
+
+      // insert actual circles
+      insert: function() {
+        return this.append("circle");
+      }
+    });
+
+    circles.on("enter", function() {
+      return this.attr("cx", function(d) {
+        return d * 10;
+      })
+      .attr("cy", 10)
+      .attr("r", 0)
+      .style("fill", "red");
+    });
+
+    circles.on("enter:transition", function() {
+      return this.delay(500)
+            .attr("r", 5)
+            .style("fill", "blue");
+    });
+  }
+});
+
+// create an instance of the chart on a d3 selection
+var chart = d3.select(output)
+  .append("svg")
+  .attr("height", 30)
+  .attr("width", 400)
+  .chart("CircleChart");
+
+// render it with some data
+chart.draw([1,4,6,9,12,13,30]);

--- a/examples/api/layer.js
+++ b/examples/api/layer.js
@@ -1,0 +1,25 @@
+// define a layer
+var layer = d3.select(output)
+  .append("svg")
+  .attr("width", 100)
+  .attr("height", 100)
+  .layer({
+    dataBind: function(data){
+      return this.selectAll("rect")
+        .data(data);
+    },
+    insert: function() {
+      return this.append("rect");
+    },
+    events: {
+      enter: function() {
+        return this.attr("x", function(d){ return d; })
+          .attr("y", 48)
+          .attr("width", 4)
+          .attr("height",4);
+      }
+    }
+  });
+
+// render the layer
+layer.draw([10,20,50,90]);

--- a/examples/api/selection-chart.js
+++ b/examples/api/selection-chart.js
@@ -1,0 +1,45 @@
+d3.chart("CircleChart", {
+  initialize: function() {
+    // add a circles layer
+    this.layer(
+      // layer name:
+      "circles",
+
+      // give it a container off of the base
+      this.base.append("g"),
+
+      {
+        // define the data binding function
+        dataBind: function(data) {
+          return this.selectAll("circle")
+            .data(data);
+        },
+        // define the element inserting 
+        insert: function() {
+          return this.append("circle");
+        },
+        // define the life cycle events
+        events: {
+          enter : function() {
+            return this.attr("cx", function(d) {
+              return d;
+            })
+            .attr("cy", 10)
+            .attr("r", this.chart().radius());
+          }
+        }
+      }
+    );
+  },
+  radius: function() {
+    return 4;
+  }
+});
+
+var chart = d3.select(output)
+  .append("svg")
+  .attr("height", 100)
+  .attr("width", 200)
+  .chart("CircleChart");
+
+chart.draw([10,15,24,53,90]);

--- a/src/chart-extensions.js
+++ b/src/chart-extensions.js
@@ -1,10 +1,24 @@
 "use strict";
 
 /**
+ * A namespace defined by [the D3.js library](http://d3js.org/). The d3.chart
+ * API is defined within this namespace.
+ * @namespace d3
+ */
+
+/**
+ * A constructor function defined by [the D3.js library](http://d3js.org/).
+ * @constructor d3.selection
+ * @memberof d3
+ */
+
+/**
  * Create a new chart constructor or return a previously-created chart
  * constructor.
  *
  * @static
+ * @memberof d3
+ * @externalExample {runnable} chart
  *
  * @param {String} name If no other arguments are specified, return the
  *        previously-created chart with this name.
@@ -27,7 +41,7 @@ d3.chart = function(name) {
  * Instantiate a chart or return the chart that the current selection belongs
  * to.
  *
- * @static
+ * @externalExample {runnable} selection-chart
  *
  * @param {String} [chartName] The name of the chart to instantiate. If the
  *        name is unspecified, this method will return the chart that the

--- a/src/chart.js
+++ b/src/chart.js
@@ -73,6 +73,9 @@ var transformCascade = function(instance, data) {
 /**
  * Create a d3.chart
  *
+ * @constructor
+ * @externalExample {runnable} chart
+ *
  * @param {d3.selection} selection The chart's "base" DOM node. This should
  *        contain any nodes that the chart generates.
  * @param {mixed} chartOptions A value for controlling how the chart should be
@@ -89,7 +92,6 @@ var transformCascade = function(instance, data) {
  * @constructor
  */
 var Chart = function(selection, chartOptions) {
-
 	this.base = selection;
 	this._layers = {};
 	this._attached = {};
@@ -116,6 +118,8 @@ Chart.prototype.initialize = function() {};
 
 /**
  * Remove a layer from the chart.
+ *
+ * @externalExample chart-unlayer
  *
  * @param {String} name The name of the layer to remove.
  *
@@ -146,6 +150,8 @@ Chart.prototype.unlayer = function(name) {
  * The {@link Layer.draw} method of attached layers will be invoked
  * whenever this chart's {@link Chart#draw} is invoked and will receive the
  * data (optionally modified by the chart's {@link Chart#transform} method.
+ *
+ * @externalExample chart-layer
  *
  * @param {String} name Name of the layer to attach or retrieve.
  * @param {d3.selection|Layer} [selection] The layer's base or a
@@ -191,6 +197,8 @@ Chart.prototype.layer = function(name, selection, options) {
  * method will be invoked whenever the containing chart's `draw` method is
  * invoked.
  *
+ * @externalExample chart-attach
+ *
  * @param {String} attachmentName Name of the attachment
  * @param {Chart} [chart] d3.chart to register as a mix in of this chart. When
  *        unspecified, this method will return the attachment previously
@@ -208,8 +216,30 @@ Chart.prototype.attach = function(attachmentName, chart) {
 };
 
 /**
+ * A "hook" method that you may define to modify input data before it is used
+ * to draw the chart's layers and attachments. This method will be used by all
+ * sub-classes (see {@link transformCascade} for details).
+ *
+ * Note you will most likely never call this method directly, but rather
+ * include it as part of a chart definition, and then rely on d3.chart to
+ * invoke it when you draw the chart with {@link Chart#draw}.
+ *
+ * @externalExample {runnable} chart-transform
+ *
+ * @param {Array} data Input data provided to @link Chart#draw}.
+ *
+ * @returns {mixed} Data to be used in drawing the chart's layers and
+ *                  attachments.
+ */
+Chart.prototype.transform = function(data) {
+	return data;
+};
+
+/**
  * Update the chart's representation in the DOM, drawing all of its layers and
  * any "attachment" charts (as attached via {@link Chart#attach}).
+ *
+ * @externalExample chart-draw
  *
  * @param {Object} data Data to pass to the {@link Layer#draw|draw method} of
  *        this cart's {@link Layer|layers} (if any) and the {@link
@@ -248,6 +278,8 @@ Chart.prototype.draw = function(data) {
  * Subscribe a callback function to an event triggered on the chart. See {@link
  * Chart#once} to subscribe a callback function to an event for one occurence.
  *
+ * @externalExample {runnable} chart-on
+ *
  * @param {String} name Name of the event
  * @param {ChartEventHandler} callback Function to be invoked when the event
  *        occurs
@@ -271,6 +303,8 @@ Chart.prototype.on = function(name, callback, context) {
  * function will be invoked at the next occurance of the event and immediately
  * unsubscribed. See {@link Chart#on} to subscribe a callback function to an
  * event indefinitely.
+ *
+ * @externalExample {runnable} chart-once
  *
  * @param {String} name Name of the event
  * @param {ChartEventHandler} callback Function to be invoked when the event
@@ -297,6 +331,8 @@ Chart.prototype.once = function(name, callback, context) {
  * function will be unsubscribed from that event. When a `name` and `context`
  * are specified (but `callback` is omitted), all events bound to the given
  * event with the given context will be unsubscribed.
+ *
+ * @externalExample {runnable} chart-off
  *
  * @param {String} [name] Name of the event to be unsubscribed
  * @param {ChartEventHandler} [callback] Function to be unsubscribed
@@ -346,6 +382,8 @@ Chart.prototype.off = function(name, callback, context) {
 /**
  * Publish an event on this chart with the given `name`.
  *
+ * @externalExample {runnable} chart-trigger
+ *
  * @param {String} name Name of the event to publish
  * @param {...*} arguments Values with which to invoke the registered
  *        callbacks.
@@ -372,9 +410,10 @@ Chart.prototype.trigger = function(name) {
  * "overrides" for the default chart instance methods. Allows for basic
  * inheritance so that new chart constructors may be defined in terms of
  * existing chart constructors. Based on the `extend` function defined by
- * {@link http://backbonejs.org/|Backbone.js}.
+ * [Backbone.js](http://backbonejs.org/).
  *
  * @static
+ * @externalExample {runnable} chart-extend
  *
  * @param {String} name Identifier for the new Chart constructor.
  * @param {Object} protoProps Properties to set on the new chart's prototype.

--- a/src/layer.js
+++ b/src/layer.js
@@ -10,6 +10,7 @@ var lifecycleRe = /^(enter|update|merge|exit)(:transition)?$/;
  *
  * @private
  * @constructor
+ * @externalExample {runnable} layer
  *
  * @param {d3.selection} base The containing DOM node for the layer.
  */
@@ -43,6 +44,8 @@ Layer.prototype.insert = function() {
  * events) are triggered when {@link Layer#draw} is invoked--see that method
  * for more details on lifecycle events.
  *
+ * @externalExample {runnable} layer-on
+ *
  * @param {String} eventName Identifier for the lifecycle event for which to
  *        subscribe.
  * @param {Function} handler Callback function
@@ -71,6 +74,8 @@ Layer.prototype.on = function(eventName, handler, options) {
 /**
  * Unsubscribe the specified handler from the specified event. If no handler is
  * supplied, remove *all* handlers from the event.
+ *
+ * @externalExample {runnable} layer-off
  *
  * @param {String} eventName Identifier for event from which to remove
  *        unsubscribe
@@ -118,6 +123,8 @@ Layer.prototype.off = function(eventName, handler) {
  * - enter:transition
  * - exit
  * - exit:transition
+ *
+ * @externalExample {runnable} layer-draw
  *
  * @param {Array} data Data to drive the rendering.
  */


### PR DESCRIPTION
Change tag usage to more accurately describe the API, and include
external examples from the Miso project website.
