### PR TITLE
Support CommonJS and fix UMD

### DIFF
--- a/src/wrapper/start.frag
+++ b/src/wrapper/start.frag
@@ -1,10 +1,12 @@
 (function(global, factory) {
 	"use strict";
 
-	if (typeof global.define === "function" && global.define.amd) {
+	if (typeof define === "function" && define.amd) {
 		define(["d3"], function(d3) {
 			factory(global, d3);
 		});
+	} else if (typeof require === "function") {
+		factory(global, require("d3"));
 	} else {
 		factory(global, global.d3);
 	}


### PR DESCRIPTION
I'm using this library with Browserify and found that it was unable to
detect d3 correctly.  This adds in the necessary `require` call to find
the d3 dependency.

I also changed the UMD signature to not expect that `define` and
`require` are globals in the sense of the runtime, but instead are
global within the encapsulating function scope (which may be the same as
the runtime's).  This will ensure d3.chart works as expected when
bundled.