### PR TITLE
Move location of built file intended for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-d3.chart.test.js
+test/d3.chart.test-build.js
 bower_components/

--- a/build/tasks/concat.js
+++ b/build/tasks/concat.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
 		},
 		test: {
 			files: {
-				"d3.chart.test.js": [
+				"test/d3.chart.test-build.js": [
 					"src/wrapper/start.frag",
 					"<%= meta.srcFiles %>",
 					"src/wrapper/end.frag"

--- a/test/index.html
+++ b/test/index.html
@@ -93,7 +93,7 @@
 					}
 				});
 
-				require(["d3.chart.test"], function() {
+				require(["test/d3.chart.test-build"], function() {
 					done();
 				});
 			}
@@ -101,7 +101,7 @@
 		global: {
 			prereqs: [
 				"../bower_components/d3/d3.js",
-				"../d3.chart.test.js"
+				"d3.chart.test-build.js"
 			],
 			setup: function(done) {
 				done();


### PR DESCRIPTION
When building the library for the purposes of testing, output the built
file to the `test/` directory. This limits the amount of
temporary/ignored (and potentially confusing) files in the top-level
directory of the project.